### PR TITLE
Id Example Tests

### DIFF
--- a/catz/src/main/scala/catz/Id.scala
+++ b/catz/src/main/scala/catz/Id.scala
@@ -1,0 +1,32 @@
+package catz
+
+
+
+object IdEx1 {
+  import cats.Id
+  import cats.Functor
+
+  val one : Int = 1
+  val onePlusOne: Id[Int] = Functor[Id].map(one)(_ + 1)
+  // onePlusOne: cats.Id[Int] = 2
+}
+
+object IdEx2 {
+  import cats.Id
+  import cats.Monad
+
+  val one : Int = 1
+  val mapOnePlusOne : Id[Int] = Monad[Id].map(one)(_ + 1)
+  // mapOnePlusOne: cats.Id[Int] = 2
+  val flatMapOnePlusOne : Id[Int] = Monad[Id].flatMap(one)(_ + 1)
+  // flatMapOnePlusOne: cats.Id[Int] = 2
+}
+
+object IdEx3 {
+  import cats.Id
+  import cats.Comonad
+
+  val one : Int = 1
+  val coflatMapOnePlusOne : Id[Int] = Comonad[Id].coflatMap(one)(_ + 1)
+  // coflatMapOnePlusOne: cats.Id[Int] = 2
+}

--- a/catz/src/main/scala/catz/Id.scala
+++ b/catz/src/main/scala/catz/Id.scala
@@ -1,7 +1,6 @@
 package catz
 
-
-
+// Id Examples Taken From http://typelevel.org/cats/typeclasses/id.html
 object IdEx1 {
   import cats.Id
   import cats.Functor

--- a/catz/src/test/scala/catz/IdTests.scala
+++ b/catz/src/test/scala/catz/IdTests.scala
@@ -1,0 +1,21 @@
+package catz
+
+class IdTests extends CatzSuite {
+
+  test("IdEx1 Functor") {
+    IdEx1.onePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Map") {
+    IdEx2.mapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Flatmap") {
+    IdEx2.flatMapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx3 Coflatmap") {
+    IdEx3.coflatMapOnePlusOne shouldBe 2
+  }
+
+}

--- a/catzScalaz/src/main/scala/catz/Id.scala
+++ b/catzScalaz/src/main/scala/catz/Id.scala
@@ -1,5 +1,6 @@
 package catz
 
+// Id Examples Taken From http://typelevel.org/cats/typeclasses/id.html
 object IdEx1 {
   import scalaz._
   import Scalaz._

--- a/catzScalaz/src/main/scala/catz/Id.scala
+++ b/catzScalaz/src/main/scala/catz/Id.scala
@@ -1,0 +1,30 @@
+package catz
+
+object IdEx1 {
+  import scalaz._
+  import Scalaz._
+
+  val one : Int = 1
+  val onePlusOne: Id[Int] = Functor[Id].map(one)(_ + 1)
+  // onePlusOne: scalaz.Scalaz.Id[Int] = 2
+}
+
+object IdEx2 {
+  import scalaz._
+  import Scalaz._
+
+  val one : Int = 1
+  val mapOnePlusOne : Id[Int] = Monad[Id].map(one)(_ + 1)
+  // mapOnePlusOne: scalaz.Scalaz.Id[Int] = 2
+  val flatMapOnePlusOne : Id[Int] = Monad[Id].bind(one)(_ + 1)
+  // flatMapOnePlusOne: scalaz.Scalaz.Id[Int] = 2
+}
+
+object IdEx3 {
+  import scalaz._
+  import Scalaz._
+
+  val one : Int = 1
+  val coflatMapOnePlusOne : Id[Int] = Comonad[Id].cobind(one)(_ + 1)
+  // coflatMapOnePlusOne: scalaz.Scalaz.Id[Int] = 2
+}

--- a/catzScalaz/src/test/scala/catz/IdTests.scala
+++ b/catzScalaz/src/test/scala/catz/IdTests.scala
@@ -1,0 +1,21 @@
+package catz
+
+class IdTests extends CatzSuite {
+
+  test("IdEx1 Functor") {
+    IdEx1.onePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Map") {
+    IdEx2.mapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Flatmap") {
+    IdEx2.flatMapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx3 Coflatmap") {
+    IdEx3.coflatMapOnePlusOne shouldBe 2
+  }
+
+}

--- a/catzXor/src/main/scala/catz/Id.scala
+++ b/catzXor/src/main/scala/catz/Id.scala
@@ -1,5 +1,6 @@
 package catz
 
+// Id Examples Taken From http://typelevel.org/cats/typeclasses/id.html
 object IdEx1 {
   import cats.Id
   import cats.Functor

--- a/catzXor/src/main/scala/catz/Id.scala
+++ b/catzXor/src/main/scala/catz/Id.scala
@@ -1,0 +1,30 @@
+package catz
+
+object IdEx1 {
+  import cats.Id
+  import cats.Functor
+
+  val one : Int = 1
+  val onePlusOne: Id[Int] = Functor[Id].map(one)(_ + 1)
+  // onePlusOne: cats.Id[Int] = 2
+}
+
+object IdEx2 {
+  import cats.Id
+  import cats.Monad
+
+  val one : Int = 1
+  val mapOnePlusOne : Id[Int] = Monad[Id].map(one)(_ + 1)
+  // mapOnePlusOne: cats.Id[Int] = 2
+  val flatMapOnePlusOne : Id[Int] = Monad[Id].flatMap(one)(_ + 1)
+  // flatMapOnePlusOne: cats.Id[Int] = 2
+}
+
+object IdEx3 {
+  import cats.Id
+  import cats.Comonad
+
+  val one : Int = 1
+  val coflatMapOnePlusOne : Id[Int] = Comonad[Id].coflatMap(one)(_ + 1)
+  // coflatMapOnePlusOne: cats.Id[Int] = 2
+}

--- a/catzXor/src/test/scala/catz/IdTests.scala
+++ b/catzXor/src/test/scala/catz/IdTests.scala
@@ -1,0 +1,21 @@
+package catz
+
+class IdTests extends CatzSuite {
+
+  test("IdEx1 Functor") {
+    IdEx1.onePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Map") {
+    IdEx2.mapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx2 Monad Flatmap") {
+    IdEx2.flatMapOnePlusOne shouldBe 2
+  }
+
+  test("IdEx3 Coflatmap") {
+    IdEx3.coflatMapOnePlusOne shouldBe 2
+  }
+
+}


### PR DESCRIPTION
Simple Id Tests

Scalaz uses `bind`/`cobind` instead of `flatmap`/`coflatMap`